### PR TITLE
Add RP ops steps vaguely instructing to verify extension outputs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2794,8 +2794,9 @@ structures.
 
 ## Registering a new credential ## {#registering-a-new-credential}
 
-When registering a new credential, represented by a {{AuthenticatorAttestationResponse}} structure |response|, as part of a
-[=registration=] [=ceremony=], a [=[RP]=] MUST proceed as follows:
+When registering a new credential, represented by a {{AuthenticatorAttestationResponse}} structure |response| and an
+{{AuthenticationExtensionsClientOutputs}} structure |clientExtensionResults|, as part of a [=registration=] [=ceremony=], a
+[=[RP]=] MUST proceed as follows:
 
 1. Let |JSONtext| be the result of
     running [=UTF-8 decode=] on the value of <code>|response|.{{AuthenticatorResponse/clientDataJSON}}</code>.
@@ -2832,6 +2833,15 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
 1. If [=user verification=] is not required for this registration, verify that the [=User Present=] bit of the
     <code>[=flags=]</code> in |authData| is set.
 
+1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
+    outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
+    extension input=] values that were given as the {{PublicKeyCredentialCreationOptions/extensions}} option in the
+    {{CredentialsContainer/create()}} call. The meaning of "are as expected" is specific to the [=[RP]=] and which extensions are
+    in use.
+
+    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST be prepared to
+    handle cases where none or not all of the requested extensions were acted upon.
+
 1. Determine the attestation statement format by performing an USASCII case-sensitive match on |fmt| against the set of
     supported WebAuthn Attestation Statement Format Identifier values.
     The up-to-date list of registered WebAuthn Attestation Statement Format Identifier values
@@ -2849,10 +2859,10 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
     example, the FIDO Metadata Service [[FIDOMetadataService]] provides one way to obtain such information, using the
     <code>[=aaguid=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|.
 
-1. Assess the attestation trustworthiness using the outputs of the verification procedure in step 13, as follows:
+1. Assess the attestation trustworthiness using the outputs of the verification procedure in step 14, as follows:
         - If [=self attestation=] was used, check if [=self attestation=] is acceptable under [=[RP]=] policy.
         - If [=ECDAA=] was used, verify that the [=identifier of the ECDAA-Issuer public key=] used is included in the set of
-            acceptable trust anchors obtained in step 14.
+            acceptable trust anchors obtained in step 15.
         - Otherwise, use the X.509 certificates returned by the verification procedure to verify that the attestation public key
             correctly chains up to an acceptable root certificate.
 
@@ -2867,7 +2877,7 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
     <code>[=credentialPublicKey=]</code> in the <code>[=attestedCredentialData=]</code> in |authData|, as appropriate for the
     [=[RP]=]'s system.
 
-1. If the attestation statement |attStmt| successfully verified but is not trustworthy per step 15 above, the [=[RP]=] SHOULD fail
+1. If the attestation statement |attStmt| successfully verified but is not trustworthy per step 16 above, the [=[RP]=] SHOULD fail
     the [=registration=] [=ceremony=].
 
     NOTE: However, if permitted by policy, the [=[RP]=] MAY register the [=credential ID=] and credential public key but treat the
@@ -2876,15 +2886,15 @@ When registering a new credential, represented by a {{AuthenticatorAttestationRe
         See [[FIDOSecRef]] and [[UAFProtocol]] for a more detailed discussion.
 
 Verification of [=attestation objects=] requires that the [=[RP]=] has a trusted method of determining acceptable trust anchors
-in step 14 above. Also, if certificates are being used, the [=[RP]=] MUST have access to certificate status information for the
+in step 15 above. Also, if certificates are being used, the [=[RP]=] MUST have access to certificate status information for the
 intermediate CA certificates. The [=[RP]=] MUST also be able to build the attestation certificate chain if the client did not
 provide this chain in the attestation information.
 
 
 ## Verifying an authentication assertion ## {#verifying-assertion}
 
-When verifying a given {{PublicKeyCredential}} structure (|credential|) as part of an [=authentication=] [=ceremony=], the
-[=[RP]=] MUST proceed as follows:
+When verifying a given {{PublicKeyCredential}} structure (|credential|) and an {{AuthenticationExtensionsClientOutputs}} structure
+|clientExtensionResults|, as part of an [=authentication=] [=ceremony=], the [=[RP]=] MUST proceed as follows:
 
 1. If the {{PublicKeyCredentialRequestOptions/allowCredentials}} option was given when this [=authentication=] [=ceremony=] was
     initiated, verify that <code>|credential|.{{Credential/id}}</code> identifies one of the [=public key credentials=] that were
@@ -2928,6 +2938,15 @@ When verifying a given {{PublicKeyCredential}} structure (|credential|) as part 
 
 1. If [=user verification=] is not required for this assertion, verify that the [=User Present=] bit of the <code>[=flags=]</code>
     in |aData| is set.
+
+1. Verify that the values of the [=client extension outputs=] in |clientExtensionResults| and the [=authenticator extension
+    outputs=] in the <code>[=authdataextensions|extensions=]</code> in |authData| are as expected, considering the [=client
+    extension input=] values that were given as the {{PublicKeyCredentialRequestOptions/extensions}} option in the
+    {{CredentialsContainer/get()}} call. The meaning of "are as expected" is specific to the [=[RP]=] and which extensions are in
+    use.
+
+    Note: Since all extensions are OPTIONAL for both the [=client=] and the [=authenticator=], the [=[RP]=] MUST be prepared to
+    handle cases where none or not all of the requested extensions were acted upon.
 
 1. Let |hash| be the result of computing a hash over the |cData| using SHA-256.
 


### PR DESCRIPTION
This would resolve the second bullet point of #804:

>- add a step to the RP operations instructing vaguely to verify that the extension outputs "are as expected".